### PR TITLE
fix: make service descriptions optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ jobs:
 services:
   mydb:
     image: "mysql:8.0"
-    description: "MySQL"
     ports:
       - "3306/tcp"
     envs:
@@ -112,10 +111,12 @@ with:
   services_yaml: |
     app:
       image: "nginx"
-      description: "Nginx"
       ports:
         - "80/tcp"
 ```
+
+> [!NOTE]
+> `description` is optional. If omitted, the action uses the service name as fallback when building the API request.
 
 ## ⚙️ Inputs
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ jobs:
 services:
   mydb:
     image: "mysql:8.0"
+    description: "MySQL"
     ports:
       - "3306/tcp"
     envs:

--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -39,14 +39,14 @@ func main() {
 		panic(loadStackDataErr)
 	}
 
+	// Set all missing required fields that can be inferred by other inputs
+	stackData = addMissingStackData(stackData)
+
 	// Run type-level validation (SDK-based) on parsed stack config
 	if validateErr := stackData.Validate(); validateErr != nil {
 		slog.Error("❌ invalid stack data")
 		panic(validateErr)
 	}
-
-	// Set all missing required fields that can be inferred by other inputs
-	stackData = addMissingStackData(stackData)
 
 	// Construct the API request to declare the stack
 	req := containerclientv2.UpdateStackRequest{
@@ -111,11 +111,20 @@ func main() {
 func addMissingStackData(stack *containerclientv2.UpdateStackRequestBody) *containerclientv2.UpdateStackRequestBody {
 	updated := *stack
 
+	// Assert that all services have a description set (required by the API)
+	for serviceName, service := range stack.Services {
+		if service.Description == nil || *service.Description == "" {
+			serviceDescription := serviceName
+			service.Description = &serviceDescription
+			updated.Services[serviceName] = service
+		}
+	}
+
 	// Assert that all volumes have a name set (required by the API)
-	for v, volume := range stack.Volumes {
-		volumeName := v
+	for volumeName, volume := range stack.Volumes {
 		if volume.Name == nil || *volume.Name == "" {
-			volume.Name = &volumeName
+			name := volumeName
+			volume.Name = &name
 			updated.Volumes[volumeName] = volume
 		}
 	}

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -137,6 +137,8 @@ volumes:
 	s.NoError(err)
 	s.NotNil(stack)
 
+	stack = addMissingStackData(stack)
+
 	s.Contains(stack.Services, "app")
 	s.Equal("nginx", *stack.Services["app"].Image)
 	s.Equal("test app", *stack.Services["app"].Description)
@@ -172,6 +174,8 @@ data:
 	stack, err := loadStackData()
 	s.NoError(err)
 	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
 
 	s.Contains(stack.Services, "app")
 	s.Equal("nginx", *stack.Services["app"].Image)
@@ -215,6 +219,8 @@ volumes:
 	s.NoError(err)
 	s.NotNil(stack)
 
+	stack = addMissingStackData(stack)
+
 	s.Contains(stack.Services, "app")
 	s.Equal("nginx", *stack.Services["app"].Image)
 	s.Equal("test app", *stack.Services["app"].Description)
@@ -252,6 +258,8 @@ data:
 	s.NoError(err)
 	s.NotNil(stack)
 
+	stack = addMissingStackData(stack)
+
 	s.Contains(stack.Services, "app")
 	s.Equal("nginx", *stack.Services["app"].Image)
 	s.Equal("test app", *stack.Services["app"].Description)
@@ -277,6 +285,74 @@ func (s *StackActionTestSuite) TestLoadStackData_FromInvalidFile() {
 	s.Contains(err.Error(), "unmarshal")
 }
 
+func (s *StackActionTestSuite) TestLoadStackData_AllowsMissingServiceDescription() {
+	os.Setenv(
+		"INPUT_STACK_YAML", `
+services:
+  app:
+    image: nginx
+    ports:
+      - "80/tcp"
+`,
+	)
+
+	stack, err := loadStackData()
+	s.NoError(err)
+	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
+
+	s.Contains(stack.Services, "app")
+	s.NotNil(stack.Services["app"].Description)
+	s.Equal("app", *stack.Services["app"].Description)
+	for _, svc := range stack.Services {
+		s.NoError(svc.Validate())
+	}
+}
+
+func (s *StackActionTestSuite) TestAddMissingStackData_FillsMissingServiceDescription() {
+	stack, err := parseStackObject(map[string]interface{}{
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
+
+	s.Contains(stack.Services, "app")
+	s.NotNil(stack.Services["app"].Description)
+	s.Equal("app", *stack.Services["app"].Description)
+	for _, svc := range stack.Services {
+		s.NoError(svc.Validate())
+	}
+}
+
+func (s *StackActionTestSuite) TestAddMissingStackData_EmptyServiceDescription() {
+	stack, err := parseStackObject(map[string]interface{}{
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image":       "nginx",
+				"description": "",
+			},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
+
+	s.Contains(stack.Services, "app")
+	s.NotNil(stack.Services["app"].Description)
+	s.Equal("app", *stack.Services["app"].Description)
+	for _, svc := range stack.Services {
+		s.NoError(svc.Validate())
+	}
+}
+
 func (s *StackActionTestSuite) TestLoadServicesToRecreate_EmptyList() {
 	os.Setenv(
 		"INPUT_STACK_YAML", `
@@ -295,6 +371,8 @@ volumes:
 	stack, err := loadStackData()
 	s.NoError(err)
 	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
 
 	servicesToRecreate := loadServicesToRecreate(stack.Services)
 	s.Len(servicesToRecreate, 1)
@@ -324,6 +402,8 @@ services:
 	stack, err := loadStackData()
 	s.NoError(err)
 	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
 
 	servicesToRecreate := loadServicesToRecreate(stack.Services)
 	s.Len(servicesToRecreate, 1)
@@ -359,6 +439,8 @@ services:
 	stack, err := loadStackData()
 	s.NoError(err)
 	s.NotNil(stack)
+
+	stack = addMissingStackData(stack)
 
 	servicesToRecreate := loadServicesToRecreate(stack.Services)
 	s.Len(servicesToRecreate, 1)


### PR DESCRIPTION
## Summary
- make the service `description` field optional in stack/service YAML input
- fill in missing or empty descriptions with the service name before validation
- document the fallback behavior and add regression tests

## Testing
- not run locally in this environment (no Go toolchain installed)